### PR TITLE
test: Add a test for GetAudioSpeech

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI/tests/AudioSpeechTests.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/AudioSpeechTests.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Azure.Core.TestFramework;
+using NUnit.Framework;
+
+namespace Azure.AI.OpenAI.Tests;
+
+public class AudioSpeechTests : OpenAITestBase
+{
+    public AudioSpeechTests(bool isAsync)
+        : base(Scenario.AudioSpeech, isAsync) // , RecordedTestMode.Live)
+    {
+    }
+
+    [RecordedTest]
+    [TestCase(Service.Azure)]
+    [TestCase(Service.NonAzure)]
+    public async Task GetAudioSpeech(Service serviceTarget)
+    {
+        OpenAIClient client = GetTestClient(serviceTarget);
+        string deploymentOrModelName = GetDeploymentOrModelName(serviceTarget);
+
+        AudioSpeechOptions requestOptions = new(
+            deploymentOrModelName, "Hello World", AudioSpeechVoice.Alloy
+        );
+
+        Response<BinaryData> response = await client.GetAudioSpeechAsync(requestOptions);
+        Assert.That(response, Is.Not.Null);
+        Assert.That(response.Value, Is.InstanceOf<BinaryData>());
+        byte[] byteArray = response.Value.ToArray();
+        Assert.That(byteArray, Is.Not.Empty);
+    }
+}

--- a/sdk/openai/Azure.AI.OpenAI/tests/AudioSpeechTests.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/AudioSpeechTests.cs
@@ -23,9 +23,11 @@ public class AudioSpeechTests : OpenAITestBase
         OpenAIClient client = GetTestClient(serviceTarget);
         string deploymentOrModelName = GetDeploymentOrModelName(serviceTarget);
 
-        AudioSpeechOptions requestOptions = new(
-            deploymentOrModelName, "Hello World", AudioSpeechVoice.Alloy
-        );
+        AudioSpeechOptions requestOptions = new(deploymentOrModelName, "Hello World", AudioSpeechVoice.Alloy)
+        {
+            ResponseFormat = AudioSpeechOutputFormat.Mp3,
+            Speed = 0.8f
+        };
 
         Response<BinaryData> response = await client.GetAudioSpeechAsync(requestOptions);
         Assert.That(response, Is.Not.Null);

--- a/sdk/openai/Azure.AI.OpenAI/tests/AudioSpeechTests.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/AudioSpeechTests.cs
@@ -30,8 +30,10 @@ public class AudioSpeechTests : OpenAITestBase
         };
 
         Response<BinaryData> response = await client.GetAudioSpeechAsync(requestOptions);
-        Assert.That(response, Is.Not.Null);
+
+        Assert.That(response?.Value, Is.Not.Null);
         Assert.That(response.Value, Is.InstanceOf<BinaryData>());
+
         byte[] byteArray = response.Value.ToArray();
         Assert.That(byteArray, Is.Not.Empty);
     }

--- a/sdk/openai/Azure.AI.OpenAI/tests/OpenAITestBase.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/OpenAITestBase.cs
@@ -382,6 +382,14 @@ namespace Azure.AI.OpenAI.Tests
                     NonAzureModelName = "whisper-1",
                 },
 
+                [Scenario.AudioSpeech] = new()
+                {
+                    AzureResourceName = "openai-sdk-test-automation-account-sweden-central",
+                    AzureResourceLocation = AzureLocation.SwedenCentral,
+                    AzureDeploymentName = "tts",
+                    NonAzureModelName = "tts-1",
+                },
+
                 [Scenario.ImageGenerations] = new()
                 {
                     AzureResourceName = "openai-sdk-test-automation-account-sweden-central",
@@ -492,6 +500,7 @@ namespace Azure.AI.OpenAI.Tests
             ChatCompletions,
             Embeddings,
             AudioTranscription,
+            AudioSpeech,
             ImageGenerations,
             LegacyImageGenerations,
             ChatTools,


### PR DESCRIPTION
# Description

This pull request adds a test for `OpenAIClient.GetAudioSpeech`. The test exercises both the Azure OpenAI and non-Azure OpenAI scenarios.

Note that the test does not meaningfully inspect the returned audio, we just check that _any_ exists.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
