### PR TITLE
tests: Add tests for `lobprob` and `top_logprob` options for chat completion

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI/assets.json
+++ b/sdk/openai/Azure.AI.OpenAI/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/openai/Azure.AI.OpenAI",
-  "Tag": "net/openai/Azure.AI.OpenAI_ad96ea3b5f"
+  "Tag": "net/openai/Azure.AI.OpenAI_194f69226e"
 }

--- a/sdk/openai/Azure.AI.OpenAI/assets.json
+++ b/sdk/openai/Azure.AI.OpenAI/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/openai/Azure.AI.OpenAI",
-  "Tag": "net/openai/Azure.AI.OpenAI_6dfe745a61"
+  "Tag": "net/openai/Azure.AI.OpenAI_ad96ea3b5f"
 }

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/ChatCompletions/ChatCompletionsOptions.Serialization.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/ChatCompletions/ChatCompletionsOptions.Serialization.cs
@@ -130,6 +130,30 @@ public partial class ChatCompletionsOptions : IUtf8JsonSerializable
             writer.WritePropertyName("seed"u8);
             writer.WriteNumberValue(Seed.Value);
         }
+        if (Optional.IsDefined(EnableLogProbabilities))
+        {
+            if (EnableLogProbabilities != null)
+            {
+                writer.WritePropertyName("logprobs"u8);
+                writer.WriteBooleanValue(EnableLogProbabilities.Value);
+            }
+            else
+            {
+                writer.WriteNull("logprobs");
+            }
+        }
+        if (Optional.IsDefined(LogProbabilitiesPerToken))
+        {
+            if (LogProbabilitiesPerToken != null)
+            {
+                writer.WritePropertyName("top_logprobs"u8);
+                writer.WriteNumberValue(LogProbabilitiesPerToken.Value);
+            }
+            else
+            {
+                writer.WriteNull("top_logprobs");
+            }
+        }
         if (Optional.IsDefined(ResponseFormat))
         {
             writer.WritePropertyName("response_format"u8);

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/ChatCompletions/ChatCompletionsOptions.Serialization.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/ChatCompletions/ChatCompletionsOptions.Serialization.cs
@@ -132,27 +132,13 @@ public partial class ChatCompletionsOptions : IUtf8JsonSerializable
         }
         if (Optional.IsDefined(EnableLogProbabilities))
         {
-            if (EnableLogProbabilities != null)
-            {
-                writer.WritePropertyName("logprobs"u8);
-                writer.WriteBooleanValue(EnableLogProbabilities.Value);
-            }
-            else
-            {
-                writer.WriteNull("logprobs");
-            }
+            writer.WritePropertyName("logprobs"u8);
+            writer.WriteBooleanValue(EnableLogProbabilities.Value);
         }
         if (Optional.IsDefined(LogProbabilitiesPerToken))
         {
-            if (LogProbabilitiesPerToken != null)
-            {
-                writer.WritePropertyName("top_logprobs"u8);
-                writer.WriteNumberValue(LogProbabilitiesPerToken.Value);
-            }
-            else
-            {
-                writer.WriteNull("top_logprobs");
-            }
+            writer.WritePropertyName("top_logprobs"u8);
+            writer.WriteNumberValue(LogProbabilitiesPerToken.Value);
         }
         if (Optional.IsDefined(ResponseFormat))
         {

--- a/sdk/openai/Azure.AI.OpenAI/tests/ChatCompletionsTests.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/ChatCompletionsTests.cs
@@ -84,6 +84,31 @@ namespace Azure.AI.OpenAI.Tests
         [RecordedTest]
         [TestCase(Service.Azure)]
         [TestCase(Service.NonAzure)]
+        public async Task ChatCompletionsLogprobs(Service serviceTarget)
+        {
+            OpenAIClient client = GetTestClient(serviceTarget);
+            // logprobs seems to only currently be live on gpt-35-turbo for azure openai
+            string deploymentOrModelName = GetDeploymentOrModelName(serviceTarget, Scenario.Completions);
+            ChatCompletionsOptions requestOptions = new()
+            {
+                DeploymentName = deploymentOrModelName,
+                Messages =
+                {
+                    new ChatRequestUserMessage("Say this is a test!"),
+                },
+                EnableLogProbabilities = true
+            };
+            Response<ChatCompletions> response = await client.GetChatCompletionsAsync(requestOptions);
+
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response.Value, Is.Not.Null);
+            Assert.That(response.Value.Choices, Is.Not.Null.Or.Empty);
+            Assert.That(response.Value.Choices[0].LogProbabilityInfo?.TokenLogProbabilityResults, Is.Not.Null.Or.Empty);
+        }
+
+        [RecordedTest]
+        [TestCase(Service.Azure)]
+        [TestCase(Service.NonAzure)]
         public async Task StreamingChatCompletions(Service serviceTarget)
         {
             OpenAIClient client = GetTestClient(serviceTarget);

--- a/sdk/openai/Azure.AI.OpenAI/tests/ChatCompletionsTests.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/ChatCompletionsTests.cs
@@ -133,10 +133,10 @@ namespace Azure.AI.OpenAI.Tests
             Assert.That(response.Value.Choices[0].LogProbabilityInfo?.TokenLogProbabilityResults, Is.Not.Null.Or.Empty);
             var probResults = response.Value.Choices[0].LogProbabilityInfo.TokenLogProbabilityResults;
 
-            foreach (ChatTokenLogProbabilityResult i in probResults)
+            foreach (ChatTokenLogProbabilityResult result in probResults)
             {
-                Assert.That(i.TopLogProbabilityEntries, Is.Not.Null.Or.Empty);
-                Assert.That(i.TopLogProbabilityEntries, Has.Count.EqualTo(topLogprobs));
+                Assert.That(result.TopLogProbabilityEntries, Is.Not.Null.Or.Empty);
+                Assert.That(result.TopLogProbabilityEntries, Has.Count.EqualTo(topLogprobs));
             }
         }
 

--- a/sdk/openai/Azure.AI.OpenAI/tests/ChatCompletionsTests.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/ChatCompletionsTests.cs
@@ -89,31 +89,6 @@ namespace Azure.AI.OpenAI.Tests
             OpenAIClient client = GetTestClient(serviceTarget);
             // logprobs seems to only currently be live on gpt-35-turbo for azure openai
             string deploymentOrModelName = GetDeploymentOrModelName(serviceTarget, Scenario.Completions);
-            ChatCompletionsOptions requestOptions = new()
-            {
-                DeploymentName = deploymentOrModelName,
-                Messages =
-                {
-                    new ChatRequestUserMessage("Say this is a test!"),
-                },
-                EnableLogProbabilities = true
-            };
-            Response<ChatCompletions> response = await client.GetChatCompletionsAsync(requestOptions);
-
-            Assert.That(response, Is.Not.Null);
-            Assert.That(response.Value, Is.Not.Null);
-            Assert.That(response.Value.Choices, Is.Not.Null.Or.Empty);
-            Assert.That(response.Value.Choices[0].LogProbabilityInfo?.TokenLogProbabilityResults, Is.Not.Null.Or.Empty);
-        }
-
-        [RecordedTest]
-        [TestCase(Service.Azure)]
-        [TestCase(Service.NonAzure)]
-        public async Task ChatCompletionsTopLogprobs(Service serviceTarget)
-        {
-            OpenAIClient client = GetTestClient(serviceTarget);
-            // logprobs seems to only currently be live on gpt-35-turbo for azure openai
-            string deploymentOrModelName = GetDeploymentOrModelName(serviceTarget, Scenario.Completions);
             int topLogprobs = 3;
             ChatCompletionsOptions requestOptions = new()
             {

--- a/sdk/openai/Azure.AI.OpenAI/tests/ChatCompletionsTests.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/ChatCompletionsTests.cs
@@ -109,6 +109,40 @@ namespace Azure.AI.OpenAI.Tests
         [RecordedTest]
         [TestCase(Service.Azure)]
         [TestCase(Service.NonAzure)]
+        public async Task ChatCompletionsTopLogprobs(Service serviceTarget)
+        {
+            OpenAIClient client = GetTestClient(serviceTarget);
+            // logprobs seems to only currently be live on gpt-35-turbo for azure openai
+            string deploymentOrModelName = GetDeploymentOrModelName(serviceTarget, Scenario.Completions);
+            int topLogprobs = 3;
+            ChatCompletionsOptions requestOptions = new()
+            {
+                DeploymentName = deploymentOrModelName,
+                Messages =
+                {
+                    new ChatRequestUserMessage("Say this is a test!"),
+                },
+                EnableLogProbabilities = true,
+                LogProbabilitiesPerToken = topLogprobs
+            };
+            Response<ChatCompletions> response = await client.GetChatCompletionsAsync(requestOptions);
+
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response.Value, Is.Not.Null);
+            Assert.That(response.Value.Choices, Is.Not.Null.Or.Empty);
+            Assert.That(response.Value.Choices[0].LogProbabilityInfo?.TokenLogProbabilityResults, Is.Not.Null.Or.Empty);
+            var probResults = response.Value.Choices[0].LogProbabilityInfo.TokenLogProbabilityResults;
+
+            foreach (ChatTokenLogProbabilityResult i in probResults)
+            {
+                Assert.That(i.TopLogProbabilityEntries, Is.Not.Null.Or.Empty);
+                Assert.That(i.TopLogProbabilityEntries, Has.Count.EqualTo(topLogprobs));
+            }
+        }
+
+        [RecordedTest]
+        [TestCase(Service.Azure)]
+        [TestCase(Service.NonAzure)]
         public async Task StreamingChatCompletions(Service serviceTarget)
         {
             OpenAIClient client = GetTestClient(serviceTarget);

--- a/sdk/openai/Azure.AI.OpenAI/tests/ChatCompletionsTests.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/ChatCompletionsTests.cs
@@ -130,8 +130,9 @@ namespace Azure.AI.OpenAI.Tests
             Assert.That(response, Is.Not.Null);
             Assert.That(response.Value, Is.Not.Null);
             Assert.That(response.Value.Choices, Is.Not.Null.Or.Empty);
-            Assert.That(response.Value.Choices[0].LogProbabilityInfo?.TokenLogProbabilityResults, Is.Not.Null.Or.Empty);
-            var probResults = response.Value.Choices[0].LogProbabilityInfo.TokenLogProbabilityResults;
+            var probResults = response.Value.Choices[0].LogProbabilityInfo?.TokenLogProbabilityResults;
+
+            Assert.That(probResults, Is.Not.Null.Or.Empty);
 
             foreach (ChatTokenLogProbabilityResult result in probResults)
             {


### PR DESCRIPTION
# Description

This pull request

* Updates the serialization for `ChatCompletionOptions` to serialize the `logprobs` and `top_logprobs` options
* Adds 2 tests to validate those scenarios.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
