### PR TITLE
test: Validate presence of `ContentFilterResults` and `PromptFilterResults` in Azure scenario

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI/tests/OpenAIImageTests.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/OpenAIImageTests.cs
@@ -56,7 +56,7 @@ namespace Azure.AI.OpenAI.Tests
             {
                 foreach (ImageGenerationData data in imageGenerations.Data)
                 {
-                    Assert.That(data.ContentFilterResults, Is.Null.Or.Empty);
+                    Assert.That(data.ContentFilterResults, Is.Not.Null.Or.Empty);
                     Assert.That(data.PromptFilterResults, Is.Not.Null.Or.Empty);
                 }
             }

--- a/sdk/openai/Azure.AI.OpenAI/tests/OpenAIImageTests.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/OpenAIImageTests.cs
@@ -50,6 +50,16 @@ namespace Azure.AI.OpenAI.Tests
             ImageGenerationData firstImageLocation = imageGenerations.Data[0];
             Assert.That(firstImageLocation, Is.Not.Null);
             Assert.That(firstImageLocation.Url, Is.Not.Null.Or.Empty);
+
+            // ContentFilterResults and PromptFilterResults are currently Azure Only
+            if (serviceTarget is Service.Azure)
+            {
+                foreach (ImageGenerationData data in imageGenerations.Data)
+                {
+                    Assert.That(data.ContentFilterResults, Is.Null.Or.Empty);
+                    Assert.That(data.PromptFilterResults, Is.Not.Null.Or.Empty);
+                }
+            }
         }
 
         [RecordedTest]

--- a/sdk/openai/Azure.AI.OpenAI/tests/OpenAIImageTests.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/OpenAIImageTests.cs
@@ -57,7 +57,28 @@ namespace Azure.AI.OpenAI.Tests
                 foreach (ImageGenerationData data in imageGenerations.Data)
                 {
                     Assert.That(data.ContentFilterResults, Is.Not.Null.Or.Empty);
+
+                    Assert.That(data.ContentFilterResults.Hate.Filtered, Is.False);
+                    Assert.That(data.ContentFilterResults.Sexual.Filtered, Is.False);
+                    Assert.That(data.ContentFilterResults.Violence.Filtered, Is.False);
+                    Assert.That(data.ContentFilterResults.SelfHarm.Filtered, Is.False);
+
+                    Assert.That(data.ContentFilterResults.Hate.Severity, Is.EqualTo(ContentFilterSeverity.Safe));
+                    Assert.That(data.ContentFilterResults.Sexual.Severity, Is.EqualTo(ContentFilterSeverity.Safe));
+                    Assert.That(data.ContentFilterResults.Violence.Severity, Is.EqualTo(ContentFilterSeverity.Safe));
+                    Assert.That(data.ContentFilterResults.SelfHarm.Severity, Is.EqualTo(ContentFilterSeverity.Safe));
+
                     Assert.That(data.PromptFilterResults, Is.Not.Null.Or.Empty);
+
+                    Assert.That(data.PromptFilterResults.Hate.Filtered, Is.False);
+                    Assert.That(data.PromptFilterResults.Sexual.Filtered, Is.False);
+                    Assert.That(data.PromptFilterResults.Violence.Filtered, Is.False);
+                    Assert.That(data.PromptFilterResults.SelfHarm.Filtered, Is.False);
+
+                    Assert.That(data.PromptFilterResults.Hate.Severity, Is.EqualTo(ContentFilterSeverity.Safe));
+                    Assert.That(data.PromptFilterResults.Sexual.Severity, Is.EqualTo(ContentFilterSeverity.Safe));
+                    Assert.That(data.PromptFilterResults.Violence.Severity, Is.EqualTo(ContentFilterSeverity.Safe));
+                    Assert.That(data.PromptFilterResults.SelfHarm.Severity, Is.EqualTo(ContentFilterSeverity.Safe));
                 }
             }
         }

--- a/sdk/openai/Azure.AI.OpenAI/tests/OpenAIImageTests.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/OpenAIImageTests.cs
@@ -52,7 +52,7 @@ namespace Azure.AI.OpenAI.Tests
             Assert.That(firstImageLocation.Url, Is.Not.Null.Or.Empty);
 
             // ContentFilterResults and PromptFilterResults are currently Azure Only
-            if (serviceTarget is Service.Azure)
+            if (serviceTarget == Service.Azure)
             {
                 foreach (ImageGenerationData data in imageGenerations.Data)
                 {


### PR DESCRIPTION
# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
